### PR TITLE
feat: Create a *dependency cycle* detection injector

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,3 +47,13 @@
 - Internal improvements
     - Change `BindKey` type to prevent misplace errors
     - Remove duplicate use of **storage**
+
+## 20220801 - remy/v1.4.0
+
+- Create `CycleDetectorInjector` to be used in tests
+    - Create a new error type
+    - Create a new type in internal utilities
+- Change use of unexported type to an exported in public pkg
+    - remy public functions now use `Bind[T]` instead of `types.Bind[T]`
+- Add `WrapRetriever` to **DependencyRetriever** interface
+- Add panic recover to `Do` functions

--- a/remy/README.md
+++ b/remy/README.md
@@ -283,3 +283,9 @@ func TestCycles(t *testing.T) {
 	}
 }
 ```
+
+#### Important Note
+
+When using the `CycleDetectorInjector` is important that in Binds, all _Get_ methods used call the
+given `DependencyRetriever`, if the same injector is used inside the function, as a clojure, it will not be able to
+detect cycles.

--- a/remy/binds.go
+++ b/remy/binds.go
@@ -12,7 +12,7 @@ import (
 //
 // It's recommended to use it only for read value injections.
 // For concurrent mutable binds is recommended to use Singleton or LazySingleton
-func Instance[T any](binder types.Binder[T]) types.Bind[T] {
+func Instance[T any](binder types.Binder[T]) Bind[T] {
 	return binds.Instance(binder)
 }
 
@@ -24,7 +24,7 @@ func Instance[T any](binder types.Binder[T]) types.Bind[T] {
 // As this bind doesn't hold any pointer and/or objects, there is no problem to use it in multiples goroutines at once.
 // Just be careful with calls of the DependencyRetriever,
 // if try to get and modify values from an Instance bind, it can end in a race-condition.
-func Factory[T any](binder types.Binder[T]) types.Bind[T] {
+func Factory[T any](binder types.Binder[T]) Bind[T] {
 	return binds.Factory(binder)
 }
 
@@ -33,7 +33,7 @@ func Factory[T any](binder types.Binder[T]) types.Bind[T] {
 // The default singleton bind will execute the types.Binder during the bind registration process.
 //
 // If you don't want to generate the bind immediately at its registration, you can use the LazySingleton bind.
-func Singleton[T any](binder types.Binder[T]) types.Bind[T] {
+func Singleton[T any](binder types.Binder[T]) Bind[T] {
 	return binds.Singleton(binder)
 }
 
@@ -41,6 +41,6 @@ func Singleton[T any](binder types.Binder[T]) types.Bind[T] {
 // bind. So, it only will generate the singleton instance on the first Get call.
 //
 // It is useful in cases that you want to instantiate heavier objects only when it's needed.
-func LazySingleton[T any](binder types.Binder[T]) types.Bind[T] {
+func LazySingleton[T any](binder types.Binder[T]) Bind[T] {
 	return binds.LazySingleton(binder)
 }

--- a/remy/cycle_detector_injector.go
+++ b/remy/cycle_detector_injector.go
@@ -1,0 +1,100 @@
+package remy
+
+import (
+	"github.com/wrapped-owls/goremy-di/remy/internal/types"
+	"github.com/wrapped-owls/goremy-di/remy/internal/utils"
+)
+
+type CycleDetectorInjector struct {
+	ij              Injector
+	dependencyGraph *types.DependencyGraph
+	config          Config
+}
+
+func NewCycleDetectorInjector(configs ...Config) *CycleDetectorInjector {
+	var config Config
+	if len(configs) > 0 {
+		config = configs[0]
+	}
+	return &CycleDetectorInjector{ij: NewInjector(config), config: config}
+}
+
+func (c CycleDetectorInjector) Bind(key types.BindKey, element any) error {
+	return c.ij.Bind(key, element)
+}
+
+func (c CycleDetectorInjector) BindNamed(key types.BindKey, name string, element any) error {
+	return c.ij.BindNamed(key, name, element)
+}
+
+func (c CycleDetectorInjector) SubInjector(allowOverrides ...bool) types.Injector {
+	var shouldOverride bool
+	if len(allowOverrides) > 0 {
+		shouldOverride = allowOverrides[0]
+	}
+	inj := NewCycleDetectorInjector(Config{
+		ParentInjector:     c,
+		CanOverride:        shouldOverride,
+		GenerifyInterfaces: c.config.GenerifyInterfaces,
+		UseReflectionType:  c.config.UseReflectionType,
+	})
+	return inj
+}
+
+func (c CycleDetectorInjector) WrapRetriever() Injector {
+	inj := NewCycleDetectorInjector(c.config)
+	inj.ij = c.ij
+	newGraph := types.DependencyGraph{
+		UnnamedDependency: types.BindDependencies[bool]{},
+		NamedDependency:   types.BindDependencies[map[string]bool]{},
+	}
+	if c.dependencyGraph == nil {
+		inj.dependencyGraph = &newGraph
+	} else {
+		for key, value := range c.dependencyGraph.NamedDependency {
+			nameMap := map[string]bool{}
+			for name, used := range value {
+				nameMap[name] = used
+			}
+			newGraph.NamedDependency[key] = nameMap
+		}
+		for key, value := range c.dependencyGraph.UnnamedDependency {
+			newGraph.UnnamedDependency[key] = value
+		}
+		inj.dependencyGraph = &newGraph
+	}
+	return inj
+}
+
+func (c CycleDetectorInjector) GetNamed(key types.BindKey, name string) (any, error) {
+	if c.dependencyGraph != nil {
+		nameMap, ok := c.dependencyGraph.NamedDependency[key]
+		if !ok {
+			nameMap = map[string]bool{}
+		}
+		if _, hasKey := nameMap[name]; hasKey {
+			panic(utils.ErrCycleDependencyDetected)
+		}
+		nameMap[name] = true
+		c.dependencyGraph.NamedDependency[key] = nameMap
+	}
+	return c.ij.GetNamed(key, name)
+}
+
+func (c CycleDetectorInjector) Get(key types.BindKey) (any, error) {
+	if c.dependencyGraph != nil {
+		if _, hasKey := c.dependencyGraph.UnnamedDependency[key]; hasKey {
+			panic(utils.ErrCycleDependencyDetected)
+		} else {
+			c.dependencyGraph.UnnamedDependency[key] = true
+		}
+	}
+	return c.ij.Get(key)
+}
+
+func (c CycleDetectorInjector) ReflectOpts() types.ReflectionOptions {
+	return types.ReflectionOptions{
+		GenerifyInterface: c.config.GenerifyInterfaces,
+		UseReflectionType: c.config.UseReflectionType,
+	}
+}

--- a/remy/cycle_detector_injector_test.go
+++ b/remy/cycle_detector_injector_test.go
@@ -16,7 +16,7 @@ func TestCycleDetectorInjector_Register(t *testing.T) {
 	ij := NewCycleDetectorInjector(Config{CanOverride: false})
 	var cycleKey = [...]string{"lang", "tool"}
 	Register(ij, Factory(func(retriever DependencyRetriever) string {
-		return Get[string](ij, cycleKey[0]) + " is awesome"
+		return Get[string](retriever, cycleKey[0]) + " is awesome"
 	}))
 	Register(ij, Factory(func(retriever DependencyRetriever) string {
 		return "git" + Get[string](retriever)
@@ -25,7 +25,7 @@ func TestCycleDetectorInjector_Register(t *testing.T) {
 		return "Go + " + Get[string](retriever, cycleKey[1])
 	}), cycleKey[0])
 	Register(ij, Instance(func(retriever DependencyRetriever) int {
-		return len(Get[string](ij, cycleKey[0]))
+		return len(Get[string](retriever, cycleKey[0]))
 	}))
 }
 

--- a/remy/cycle_detector_injector_test.go
+++ b/remy/cycle_detector_injector_test.go
@@ -1,0 +1,32 @@
+package remy
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCycleDetectorInjector_Get(t *testing.T) {
+	ij := NewCycleDetectorInjector(Config{CanOverride: true})
+	const cycleKey = "name"
+	RegisterInstance(ij, "go")
+	RegisterInstance(ij, uint8(42))
+	Register(ij, Factory(func(retriever DependencyRetriever) string {
+		return fmt.Sprintf(
+			"The lenght for the string `%s` is %d ",
+			Get[string](retriever), Get[uint8](retriever),
+		)
+	}), cycleKey)
+
+	if _, err := DoGet[string](ij, cycleKey); err != nil {
+		t.Errorf("Something went wrong during normal utilization, raise: %v", err)
+	}
+
+	// overrides a dependency to insert a cycle
+	Override(ij, Factory(func(retriever DependencyRetriever) uint8 {
+		return uint8(len(Get[string](retriever, cycleKey)))
+	}))
+	_, err := DoGet[string](ij, cycleKey)
+	if err == nil {
+		t.Error("function executes normally when it should raise an error")
+	}
+}

--- a/remy/internal/injector/methods.go
+++ b/remy/internal/injector/methods.go
@@ -48,6 +48,9 @@ func Get[T any](retriever types.DependencyRetriever, keys ...string) (T, error) 
 		err  error
 	)
 
+	if wrappedRetriever := retriever.WrapRetriever(); wrappedRetriever != nil {
+		retriever = wrappedRetriever
+	}
 	// search in dynamic injections that needed to run a given function
 	if len(key) > 0 {
 		bind, err = retriever.GetNamed(elementType, key)

--- a/remy/internal/injector/methods.go
+++ b/remy/internal/injector/methods.go
@@ -13,9 +13,13 @@ func Register[T any](ij types.Injector, bind types.Bind[T], keys ...string) erro
 	}
 
 	elementType := utils.GetKey[T](ij.ReflectOpts())
+	var retriever types.DependencyRetriever = ij
+	if wrappedRetriever := retriever.WrapRetriever(); wrappedRetriever != nil {
+		retriever = wrappedRetriever
+	}
 	if insBind, ok := bind.(binds.InstanceBind[T]); ok {
 		if !insBind.IsFactory {
-			value := insBind.Generates(ij)
+			value := insBind.Generates(retriever)
 			if len(key) > 0 {
 				return ij.BindNamed(elementType, key, value)
 			}
@@ -23,7 +27,7 @@ func Register[T any](ij types.Injector, bind types.Bind[T], keys ...string) erro
 		}
 	} else if sglBind, assertOk := bind.(*binds.SingletonBind[T]); assertOk {
 		if !sglBind.IsLazy && sglBind.ShouldGenerate() {
-			sglBind.BuildDependency(ij)
+			sglBind.BuildDependency(retriever)
 		}
 	}
 

--- a/remy/internal/injector/standard_injector.go
+++ b/remy/internal/injector/standard_injector.go
@@ -36,6 +36,10 @@ func (s *StdInjector) SubInjector(overrides ...bool) types.Injector {
 	return New(canOverride, s.reflectOpts, s)
 }
 
+func (s *StdInjector) WrapRetriever() types.Injector {
+	return nil
+}
+
 func (s StdInjector) ReflectOpts() types.ReflectionOptions {
 	return s.reflectOpts
 }

--- a/remy/internal/types/injector.go
+++ b/remy/internal/types/injector.go
@@ -30,12 +30,16 @@ type (
 	}
 
 	// DependencyRetriever is the main element used to obtain registered binds/instances
-	DependencyRetriever = ValuesGetter[BindKey]
+	DependencyRetriever interface {
+		ValuesGetter[BindKey]
+		WrapRetriever() Injector
+	}
 
 	// Injector is the main interface that contains all needed methods to make an injector work
 	Injector interface {
 		Bind(BindKey, any) error
 		BindNamed(BindKey, string, any) error
+		SubInjector(allowOverrides ...bool) Injector
 		DependencyRetriever
 	}
 )

--- a/remy/internal/types/utilities.go
+++ b/remy/internal/types/utilities.go
@@ -12,4 +12,10 @@ type (
 		GenerifyInterface bool
 		UseReflectionType bool
 	}
+
+	BindDependencies[T any] map[BindKey]T
+	DependencyGraph         struct {
+		UnnamedDependency BindDependencies[bool]
+		NamedDependency   BindDependencies[map[string]bool]
+	}
 )

--- a/remy/internal/utils/errors.go
+++ b/remy/internal/utils/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrImpossibleIdentifyType       = errors.New("impossible to identify the given type")
 	ErrElementNotRegistered         = errors.New("element with given key is not registered")
 	ErrNoElementFoundInsideOrParent = errors.New("no element found on the given injector or any of it's parents")
+	ErrCycleDependencyDetected      = errors.New("cycle dependency detected, check for it")
 )

--- a/remy/remy.go
+++ b/remy/remy.go
@@ -14,7 +14,7 @@ type (
 
 	// Bind is directly copy from types.Bind
 	Bind[T any] interface {
-		Generates(DependencyRetriever) T
+		types.Bind[T]
 	}
 
 	// Config defines needed configuration to instantiate a new injector
@@ -61,11 +61,11 @@ func NewInjector(configs ...Config) Injector {
 
 // Register must be called first, because the library doesn't support registering dependencies while get at same time.
 // This is not supported in multithreading applications because it does not have race protection
-func Register[T any](i Injector, bind types.Bind[T], keys ...string) {
+func Register[T any](i Injector, bind Bind[T], keys ...string) {
 	if i == nil {
 		i = globalInjector()
 	}
-	if err := injector.Register(i, bind, keys...); err != nil {
+	if err := injector.Register[T](i, bind, keys...); err != nil {
 		panic(err)
 	}
 }
@@ -75,11 +75,11 @@ func Register[T any](i Injector, bind types.Bind[T], keys ...string) {
 // the library doesn't support registering dependencies while get at same time.
 //
 // This is not supported in multithreading applications because it does not have race protection
-func Override[T any](i Injector, bind types.Bind[T], keys ...string) {
+func Override[T any](i Injector, bind Bind[T], keys ...string) {
 	if i == nil {
 		i = globalInjector()
 	}
-	if err := injector.Register(i, bind, keys...); err != nil && !errors.Is(err, utils.ErrAlreadyBound) {
+	if err := injector.Register[T](i, bind, keys...); err != nil && !errors.Is(err, utils.ErrAlreadyBound) {
 		panic(err)
 	}
 }

--- a/remy/remy.go
+++ b/remy/remy.go
@@ -2,6 +2,7 @@ package remy
 
 import (
 	"errors"
+	"fmt"
 	"github.com/wrapped-owls/goremy-di/remy/internal/injector"
 	"github.com/wrapped-owls/goremy-di/remy/internal/types"
 	"github.com/wrapped-owls/goremy-di/remy/internal/utils"
@@ -124,7 +125,13 @@ func Get[T any](i DependencyRetriever, keys ...string) T {
 // Additionally, it returns an error which indicates if the bind was found or not.
 //
 // Receives: DependencyRetriever (required); key (optional)
-func DoGet[T any](i DependencyRetriever, keys ...string) (T, error) {
+func DoGet[T any](i DependencyRetriever, keys ...string) (result T, err error) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
 	if i == nil {
 		i = globalInjector()
 	}
@@ -145,7 +152,13 @@ func GetGen[T any](ij Injector, elements []InstancePairAny, keys ...string) T {
 // Additionally, it returns an error which indicates if the bind was found or not.
 //
 // Receives: Injector (required); []InstancePairAny (required); key (optional)
-func DoGetGen[T any](ij Injector, elements []InstancePairAny, keys ...string) (T, error) {
+func DoGetGen[T any](ij Injector, elements []InstancePairAny, keys ...string) (result T, err error) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
 	if ij == nil {
 		ij = globalInjector()
 	}
@@ -166,7 +179,13 @@ func GetGenFunc[T any](ij types.Injector, binder func(Injector), keys ...string)
 // Additionally, it returns an error which indicates if the bind was found or not.
 //
 // Receives: Injector (required); func(Injector) (required); key (optional)
-func DoGetGenFunc[T any](ij types.Injector, binder func(Injector), keys ...string) (T, error) {
+func DoGetGenFunc[T any](ij types.Injector, binder func(Injector), keys ...string) (result T, err error) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
 	if ij == nil {
 		ij = globalInjector()
 	}


### PR DESCRIPTION
- Create `CycleDetectorInjector` to be used in tests
    - Create a new error type
    - Create a new type in internal utilities
- Change use of unexported type to an exported in public pkg
    - remy public functions now use `Bind[T]` instead of `types.Bind[T]`
- Add `WrapRetriever` to **DependencyRetriever** interface
- Add panic recover to `Do` functions