### PR TITLE
feature: [breaking change] Add error return during register time

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,3 +73,8 @@
     - This example needs to use unexported packages yet, so it will need update after the release
 - Update `bind.Instance` to not use **remy.Binder** functions
 - Change `RegisterSingleton` function signature
+
+## 20221006 - remy/v1.6.0
+
+- Change `remy.Binder` to return an error alongside with the value
+    - Update all tests to match the new Binder function

--- a/remy/README.md
+++ b/remy/README.md
@@ -80,12 +80,8 @@ func init() {
 	remy.Register(
 		core.Injector,
 		remy.Singleton(
-			func(retriever remy.DependencyRetriever) *sql.DB {
-				db, err := sql.Open("sqlite3", "file:locked.sqlite?cache=shared&mode=memory")
-				if err != nil {
-					panic(err)
-				}
-				return db
+			func(retriever remy.DependencyRetriever) (*sql.DB, error) {
+				return sql.Open("sqlite3", "file:locked.sqlite?cache=shared&mode=memory")
 			},
 		),
 	)
@@ -106,12 +102,8 @@ import (
 // Create an instance of the database connection
 func init() {
 	remy.RegisterSingleton(
-		core.Injector, func(retriever remy.DependencyRetriever) *sql.DB {
-			db, err := sql.Open("sqlite3", "file:locked.sqlite?cache=shared&mode=memory")
-			if err != nil {
-				panic(err)
-			}
-			return db
+		core.Injector, func(retriever remy.DependencyRetriever) (*sql.DB, error) {
+			return sql.Open("sqlite3", "file:locked.sqlite?cache=shared&mode=memory")
 		},
 	)
 }
@@ -157,8 +149,9 @@ func init() {
 	remy.Register(
 		core.Injector,
 		remy.Factory(
-			func(retriever remy.DependencyRetriever) core.GenericRepository {
-				return repositories.NewGenericDbRepository(remy.Get[*sql.DB](retriever))
+			func(retriever remy.DependencyRetriever) (repo core.GenericRepository, err error) {
+				repo = repositories.NewGenericDbRepository(remy.Get[*sql.DB](retriever))
+				return
 			},
 		),
 	)
@@ -211,11 +204,12 @@ import "github.com/wrapped-owls/goremy-di/remy"
 func init() {
 	remy.Register(
 		nil, remy.Factory(
-			func(injector remy.DependencyRetriever) string {
-				return fmt.Sprintf(
+			func(injector remy.DependencyRetriever) (result string, err error) {
+				result = fmt.Sprintf(
 					"I love %s, yes this is %v, as the answer %d",
 					remy.Get[string](injector, "lang"), remy.Get[bool](injector), remy.Get[uint8](injector),
 				)
+				return
 			},
 		),
 	)
@@ -267,10 +261,11 @@ import "github.com/wrapped-owls/goremy-di/remy"
 
 func main() {
 	remy.GetGenFunc[string](
-		injector, func(injector remy.Injector) {
+		injector, func(injector remy.Injector) error {
 			remy.Register(ij, remy.Instance[uint8](42))
 			remy.Register(ij, remy.Instance("Go"), "lang")
 			remy.Register(ij, remy.Instance(true))
+			return nil
 		},
 	)
 }

--- a/remy/global_injector_test.go
+++ b/remy/global_injector_test.go
@@ -23,10 +23,14 @@ func TestGlobal_GetWithConcurrency(t *testing.T) {
 func TestSetGlobalInjector(t *testing.T) {
 	ij := NewInjector()
 	var counter uint8 = 0
-	Register(ij, Factory(func(retriever DependencyRetriever) uint8 {
-		counter += 1
-		return counter
-	}))
+	Register(
+		ij, Factory(
+			func(retriever DependencyRetriever) (uint8, error) {
+				counter += 1
+				return counter, nil
+			},
+		),
+	)
 
 	value := Get[uint8](ij)
 	if value != 1 {

--- a/remy/internal/binds/bind_factory.go
+++ b/remy/internal/binds/bind_factory.go
@@ -7,7 +7,7 @@ type FactoryBind[T any] struct {
 	binder    types.Binder[T]
 }
 
-func (b FactoryBind[T]) Generates(injector types.DependencyRetriever) T {
+func (b FactoryBind[T]) Generates(injector types.DependencyRetriever) (T, error) {
 	return b.binder(injector)
 }
 

--- a/remy/internal/binds/bind_test.go
+++ b/remy/internal/binds/bind_test.go
@@ -14,16 +14,19 @@ func TestSingletonBind_Generates(t *testing.T) {
 	)
 
 	bind := Singleton[*string](
-		func(retriever types.DependencyRetriever) *string {
+		func(retriever types.DependencyRetriever) (*string, error) {
 			counter += 1
-			return &expected
+			return &expected, nil
 		},
 	)
 	// Checks if the build method is called only once
 	for index := 0; index < 10; index++ {
 		wg.Add(1)
 		go func() {
-			result := bind.Generates(nil)
+			result, err := bind.Generates(nil)
+			if err != nil {
+				t.Error(err)
+			}
 			if result != &expected {
 				t.Fail()
 			}

--- a/remy/internal/binds/bind_test.go
+++ b/remy/internal/binds/bind_test.go
@@ -1,9 +1,10 @@
 package binds
 
 import (
-	"github.com/wrapped-owls/goremy-di/remy/internal/types"
 	"sync"
 	"testing"
+
+	"github.com/wrapped-owls/goremy-di/remy/internal/types"
 )
 
 func TestSingletonBind_Generates(t *testing.T) {

--- a/remy/internal/binds/constructors.go
+++ b/remy/internal/binds/constructors.go
@@ -24,8 +24,8 @@ func Factory[T any](binder types.Binder[T]) types.Bind[T] {
 
 func Instance[T any](element T) types.Bind[T] {
 	return FactoryBind[T]{
-		binder: func(retriever types.DependencyRetriever) T {
-			return element
+		binder: func(retriever types.DependencyRetriever) (T, error) {
+			return element, nil
 		},
 	}
 }

--- a/remy/internal/injector/injection_test.go
+++ b/remy/internal/injector/injection_test.go
@@ -100,9 +100,9 @@ func TestInjection__RetrieveSameTypeDifferentKey(t *testing.T) {
 		"go",
 	}
 	a := binds.Singleton(
-		func(ij types.DependencyRetriever) string {
+		func(ij types.DependencyRetriever) (string, error) {
 			language := TryGet[string](ij, "lang")
-			return resultParts[0] + language
+			return resultParts[0] + language, nil
 		},
 	)
 

--- a/remy/internal/injector/standard_injector_test.go
+++ b/remy/internal/injector/standard_injector_test.go
@@ -16,17 +16,17 @@ func TestStdInjector_SubInjector(t *testing.T) {
 	var counter uint8 = 0
 	_ = Register(
 		parent, binds.Factory(
-			func(retriever types.DependencyRetriever) uint8 {
+			func(retriever types.DependencyRetriever) (uint8, error) {
 				counter++
-				return counter
+				return counter, nil
 			},
 		),
 	)
 
 	_ = Register(
 		subInjector, binds.Factory(
-			func(retriever types.DependencyRetriever) string {
-				return fmt.Sprintf("%s %d", strFirstHalf, TryGet[uint8](retriever))
+			func(retriever types.DependencyRetriever) (string, error) {
+				return fmt.Sprintf("%s %d", strFirstHalf, TryGet[uint8](retriever)), nil
 			},
 		),
 	)
@@ -76,16 +76,16 @@ func TestStdInjector_SubInjector__OverrideParent(t *testing.T) {
 
 	_ = Register(
 		parent, binds.Factory(
-			func(retriever types.DependencyRetriever) uint8 {
-				return 101
+			func(retriever types.DependencyRetriever) (uint8, error) {
+				return 101, nil
 			},
 		),
 	)
 
 	_ = Register(
 		subInjector, binds.Factory(
-			func(retriever types.DependencyRetriever) string {
-				return fmt.Sprintf("%s %d", strFirstHalf, TryGet[uint8](retriever))
+			func(retriever types.DependencyRetriever) (string, error) {
+				return fmt.Sprintf("%s %d", strFirstHalf, TryGet[uint8](retriever)), nil
 			},
 		),
 	)
@@ -101,8 +101,8 @@ func TestStdInjector_SubInjector__OverrideParent(t *testing.T) {
 	// Register a new uint8 to override parent
 	_ = Register(
 		subInjector, binds.Singleton(
-			func(retriever types.DependencyRetriever) uint8 {
-				return 42
+			func(retriever types.DependencyRetriever) (uint8, error) {
+				return 42, nil
 			},
 		),
 	)

--- a/remy/internal/types/binds.go
+++ b/remy/internal/types/binds.go
@@ -2,9 +2,9 @@ package types
 
 type (
 	BindType      uint8
-	Binder[T any] func(DependencyRetriever) T
+	Binder[T any] func(DependencyRetriever) (T, error)
 	Bind[T any]   interface {
-		Generates(DependencyRetriever) T
+		Generates(DependencyRetriever) (T, error)
 		Type() BindType
 	}
 )

--- a/remy/remy.go
+++ b/remy/remy.go
@@ -150,7 +150,7 @@ func DoGetGen[T any](i DependencyRetriever, elements []InstancePairAny, keys ...
 // GetGenFunc creates a sub-injector and access the retriever to generate and return a Factory bind
 //
 // Receives: DependencyRetriever (required); func(Injector) (required); key (optional)
-func GetGenFunc[T any](i DependencyRetriever, binder func(Injector), keys ...string) T {
+func GetGenFunc[T any](i DependencyRetriever, binder func(Injector) error, keys ...string) T {
 	return injector.TryGetGenFunc[T](mustRetriever(i), binder, keys...)
 }
 
@@ -158,7 +158,7 @@ func GetGenFunc[T any](i DependencyRetriever, binder func(Injector), keys ...str
 // Additionally, it returns an error which indicates if the bind was found or not.
 //
 // Receives: DependencyRetriever (required); func(Injector) (required); key (optional)
-func DoGetGenFunc[T any](i DependencyRetriever, binder func(Injector), keys ...string) (result T, err error) {
+func DoGetGenFunc[T any](i DependencyRetriever, binder func(Injector) error, keys ...string) (result T, err error) {
 	defer func() {
 		r := recover()
 		if r != nil {


### PR DESCRIPTION
- Change `remy.Binder` to return an error alongside with the value
    - Update all tests to match the new Binder function
