### PR TITLE
feature: Add interface option for `InstancePair` in GetGen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,3 +78,6 @@
 
 - Change `remy.Binder` to return an error alongside with the value
     - Update all tests to match the new Binder function
+- Add new option in `InstancePair` to bind interfaces
+- Change the internal use of `ReflectionOptions` to use bitwise operators
+    - In this way it'll be possible to add more internal options in the future

--- a/remy/README.md
+++ b/remy/README.md
@@ -220,8 +220,8 @@ The requested values can be passed by two forms:
 
 ##### Using InstancePair array
 
-With this method is not possible to register correctly interfaces, so in case the factory binds requests an interface
-value, is better to use the other method.
+This is the most straightforward way to register temporary binds that will only be used in the `Get` call. When use this
+way to register interface types, double of the attention is required, as it doesn't have compile-time type assertion.
 
 ```go
 package main
@@ -244,6 +244,9 @@ func main() {
 			},
 			{
 				Value: true,
+			},
+			{
+				InstanceValue: (*error)(nil),
 			},
 		},
 	)

--- a/remy/internal/injector/methods.go
+++ b/remy/internal/injector/methods.go
@@ -81,20 +81,20 @@ func GetGen[T any](retriever types.DependencyRetriever, elements []types.Instanc
 	subInjector := New(false, retriever.ReflectOpts(), retriever)
 	for _, element := range elements {
 		var (
-			opts  = keyopts.FromReflectOpts(subInjector.ReflectOpts())
-			value = element.Value
+			opts       = keyopts.FromReflectOpts(subInjector.ReflectOpts())
+			typeSeeker = element.Value
 		)
-		if element.IsInterface {
+		if element.InterfaceValue != nil {
 			opts |= keyopts.KeyOptIgnorePointer
-			value = utils.GetPointerValue(value)
+			typeSeeker = element.InterfaceValue
 		}
-		bindKey := utils.GetElemKey(element.Value, opts)
+		bindKey := utils.GetElemKey(typeSeeker, opts)
 
 		if element.Key != "" {
-			if err = subInjector.BindNamed(bindKey, element.Key, value); err != nil {
+			if err = subInjector.BindNamed(bindKey, element.Key, element.Value); err != nil {
 				return
 			}
-		} else if err = subInjector.Bind(bindKey, value); err != nil {
+		} else if err = subInjector.Bind(bindKey, element.Value); err != nil {
 			return
 		}
 	}

--- a/remy/internal/injector/methods.go
+++ b/remy/internal/injector/methods.go
@@ -2,6 +2,7 @@ package injector
 
 import (
 	"github.com/wrapped-owls/goremy-di/remy/internal/types"
+	"github.com/wrapped-owls/goremy-di/remy/pkg/keyopts"
 	"github.com/wrapped-owls/goremy-di/remy/pkg/utils"
 )
 
@@ -11,7 +12,7 @@ func Register[T any](ij types.Injector, bind types.Bind[T], keys ...string) erro
 		key = keys[0]
 	}
 
-	elementType := utils.GetKey[T](ij.ReflectOpts())
+	elementType := utils.GetKey[T](keyopts.FromReflectOpts(ij.ReflectOpts()))
 	var retriever types.DependencyRetriever = ij
 	if wrappedRetriever := retriever.WrapRetriever(); wrappedRetriever != nil {
 		retriever = wrappedRetriever
@@ -39,7 +40,7 @@ func Get[T any](retriever types.DependencyRetriever, keys ...string) (T, error) 
 	if len(keys) > 0 {
 		key = keys[0]
 	}
-	elementType := utils.GetKey[T](retriever.ReflectOpts())
+	elementType := utils.GetKey[T](keyopts.FromReflectOpts(retriever.ReflectOpts()))
 
 	var (
 		bind any
@@ -79,12 +80,21 @@ func GetGen[T any](retriever types.DependencyRetriever, elements []types.Instanc
 ) {
 	subInjector := New(false, retriever.ReflectOpts(), retriever)
 	for _, element := range elements {
-		bindKey := utils.GetElemKey(element.Value, subInjector.ReflectOpts())
+		var (
+			opts  = keyopts.FromReflectOpts(subInjector.ReflectOpts())
+			value = element.Value
+		)
+		if element.IsInterface {
+			opts |= keyopts.KeyOptIgnorePointer
+			value = utils.GetPointerValue(value)
+		}
+		bindKey := utils.GetElemKey(element.Value, opts)
+
 		if element.Key != "" {
-			if err = subInjector.BindNamed(bindKey, element.Key, element.Value); err != nil {
+			if err = subInjector.BindNamed(bindKey, element.Key, value); err != nil {
 				return
 			}
-		} else if err = subInjector.Bind(bindKey, element.Value); err != nil {
+		} else if err = subInjector.Bind(bindKey, value); err != nil {
 			return
 		}
 	}

--- a/remy/internal/injector/methods.go
+++ b/remy/internal/injector/methods.go
@@ -75,9 +75,9 @@ func TryGet[T any](retriever types.DependencyRetriever, keys ...string) (result 
 	return
 }
 
-func GetGen[T any](retriever types.DependencyRetriever, elements []types.InstancePair[any], keys ...string) (
-	result T, err error,
-) {
+func GetGen[T any](
+	retriever types.DependencyRetriever, elements []types.InstancePair[any], keys ...string,
+) (result T, err error) {
 	subInjector := New(false, retriever.ReflectOpts(), retriever)
 	for _, element := range elements {
 		var (

--- a/remy/internal/types/utilities.go
+++ b/remy/internal/types/utilities.go
@@ -4,8 +4,9 @@ type (
 	BindKey string
 
 	InstancePair[T any] struct {
-		Value T
-		Key   string
+		Value       T
+		Key         string
+		IsInterface bool
 	}
 
 	ReflectionOptions struct {

--- a/remy/internal/types/utilities.go
+++ b/remy/internal/types/utilities.go
@@ -4,8 +4,19 @@ type (
 	BindKey string
 
 	InstancePair[T any] struct {
-		Value          T
-		Key            string
+		// Value that will be injected directly. (required)
+		Value T
+
+		// Key must be used when registering the value as a bind
+		Key string
+
+		// InterfaceValue is just a pointer to an interface that will be used to register the value properly.
+		//
+		// It must only be used as the follow: `(*fmt.Stringer)(nil)`.
+		//
+		// As the final result, the bind will be registered
+		// without the pointer. If you want to register an interface pointer, this option should not be used,
+		// and you should pass the pointer to the Value directly.
 		InterfaceValue any
 	}
 

--- a/remy/internal/types/utilities.go
+++ b/remy/internal/types/utilities.go
@@ -4,9 +4,9 @@ type (
 	BindKey string
 
 	InstancePair[T any] struct {
-		Value       T
-		Key         string
-		IsInterface bool
+		Value          T
+		Key            string
+		InterfaceValue any
 	}
 
 	ReflectionOptions struct {

--- a/remy/pkg/keyopts/key_type_opts.go
+++ b/remy/pkg/keyopts/key_type_opts.go
@@ -1,0 +1,22 @@
+package keyopts
+
+import "github.com/wrapped-owls/goremy-di/remy/internal/types"
+
+type GenOption uint8
+
+const (
+	KeyOptNone              GenOption = 0b0000
+	KeyOptGenerifyInterface GenOption = 0b0001
+	KeyOptUseReflectionType GenOption = 0b0010
+	KeyOptIgnorePointer     GenOption = 0b0100
+)
+
+func FromReflectOpts(options types.ReflectionOptions) (result GenOption) {
+	if options.UseReflectionType {
+		result |= KeyOptUseReflectionType
+	}
+	if options.GenerifyInterface {
+		result |= KeyOptGenerifyInterface
+	}
+	return
+}

--- a/remy/pkg/utils/generics.go
+++ b/remy/pkg/utils/generics.go
@@ -21,7 +21,7 @@ func interfaceTypeName[T any](shouldGenerify bool, element T) (name string) {
 	return
 }
 
-func TypeName[T any](shouldGenerify bool, elements ...T) (name string) {
+func TypeName[T any](shouldGenerify, identifyPointer bool, elements ...T) (name string) {
 	var value T
 	if len(elements) > 0 {
 		value = elements[0]
@@ -30,7 +30,7 @@ func TypeName[T any](shouldGenerify bool, elements ...T) (name string) {
 	name = fmt.Sprintf("%T", value)
 	if name == nilStr {
 		name = interfaceTypeName(shouldGenerify, value)
-	} else if strings.HasPrefix(name, "*") {
+	} else if strings.HasPrefix(name, "*") && identifyPointer {
 		name = fmt.Sprintf("pointer_&%s", name)
 	}
 	return

--- a/remy/pkg/utils/generics_test.go
+++ b/remy/pkg/utils/generics_test.go
@@ -10,9 +10,9 @@ func TestTypeName__DifferPointerFromInterface(t *testing.T) {
 	}
 
 	for _, generifyInterface := range [...]bool{true, false} {
-		interfaceTypeResult := TypeName[testInterface](generifyInterface)
-		pointerTypeResult := TypeName[*testInterface](generifyInterface)
-		doublePointerTypeResult := TypeName[**testInterface](generifyInterface)
+		interfaceTypeResult := TypeName[testInterface](generifyInterface, true)
+		pointerTypeResult := TypeName[*testInterface](generifyInterface, true)
+		doublePointerTypeResult := TypeName[**testInterface](generifyInterface, true)
 		if interfaceTypeResult == pointerTypeResult {
 			t.Error(typeNameErr)
 		}
@@ -28,9 +28,9 @@ func TestTypeNameByReflect__DifferPointerFromInterface(t *testing.T) {
 	}
 
 	for _, generifyInterface := range [...]bool{true, false} {
-		interfaceTypeResult := TypeNameByReflect[testInterface](generifyInterface)
-		pointerTypeResult := TypeNameByReflect[*testInterface](generifyInterface)
-		doublePointerTypeResult := TypeNameByReflect[**testInterface](generifyInterface)
+		interfaceTypeResult := TypeNameByReflect[testInterface](generifyInterface, true)
+		pointerTypeResult := TypeNameByReflect[*testInterface](generifyInterface, true)
+		doublePointerTypeResult := TypeNameByReflect[**testInterface](generifyInterface, true)
 		if interfaceTypeResult == pointerTypeResult {
 			t.Error(typeNameErr)
 		}

--- a/remy/pkg/utils/reflection.go
+++ b/remy/pkg/utils/reflection.go
@@ -74,7 +74,3 @@ func GetType[T any]() (foundType reflect.Type, isInterface bool) {
 	}
 	return
 }
-
-func GetPointerValue(element any) any {
-	return reflect.ValueOf(element).Elem().Interface()
-}

--- a/remy/pkg/utils/reflection.go
+++ b/remy/pkg/utils/reflection.go
@@ -44,7 +44,10 @@ func TypeNameByReflect[T any](generifyInterface, identifyPointer bool, elements 
 		return buildDuckInterfaceType(elementType)
 	}
 
-	name := fmt.Sprintf("%s/%s{###}%s", elementType.PkgPath(), elementType.Name(), fmt.Sprint(elementType))
+	name := fmt.Sprintf(
+		"%s/%s{###}%s",
+		elementType.PkgPath(), elementType.Name(), fmt.Sprint(elementType),
+	)
 	if !isInterface && identifyPointer {
 		// check if is a pointer
 		if reflect.ValueOf(value).Kind() == reflect.Ptr {

--- a/remy/pkg/utils/reflection.go
+++ b/remy/pkg/utils/reflection.go
@@ -74,3 +74,7 @@ func GetType[T any]() (foundType reflect.Type, isInterface bool) {
 	}
 	return
 }
+
+func GetPointerValue(element any) any {
+	return reflect.ValueOf(element).Elem().Interface()
+}

--- a/remy/pkg/utils/reflection.go
+++ b/remy/pkg/utils/reflection.go
@@ -24,7 +24,7 @@ func buildDuckInterfaceType(elementType reflect.Type) string {
 }
 
 // TypeNameByReflect returns a string that defines the name of the given generic type.
-func TypeNameByReflect[T any](generifyInterface bool, elements ...T) string {
+func TypeNameByReflect[T any](generifyInterface, identifyPointer bool, elements ...T) string {
 	var (
 		elementType reflect.Type
 		isInterface bool
@@ -45,7 +45,7 @@ func TypeNameByReflect[T any](generifyInterface bool, elements ...T) string {
 	}
 
 	name := fmt.Sprintf("%s/%s{###}%s", elementType.PkgPath(), elementType.Name(), fmt.Sprint(elementType))
-	if !isInterface {
+	if !isInterface && identifyPointer {
 		// check if is a pointer
 		if reflect.ValueOf(value).Kind() == reflect.Ptr {
 			name = fmt.Sprintf("pointer_&%s", name)

--- a/remy/pkg/utils/type_key.go
+++ b/remy/pkg/utils/type_key.go
@@ -1,17 +1,32 @@
 package utils
 
-import "github.com/wrapped-owls/goremy-di/remy/internal/types"
+import (
+	"github.com/wrapped-owls/goremy-di/remy/internal/types"
+	"github.com/wrapped-owls/goremy-di/remy/pkg/keyopts"
+)
 
-func GetKey[T any](options types.ReflectionOptions) types.BindKey {
-	if options.UseReflectionType {
-		return types.BindKey(TypeNameByReflect[T](options.GenerifyInterface))
-	}
-	return types.BindKey(TypeName[T](options.GenerifyInterface))
+func shouldGenerify(options keyopts.GenOption) bool {
+	return options&keyopts.KeyOptGenerifyInterface == keyopts.KeyOptGenerifyInterface
 }
 
-func GetElemKey(element any, options types.ReflectionOptions) types.BindKey {
-	if options.UseReflectionType {
-		return types.BindKey(TypeNameByReflect(options.GenerifyInterface, element))
+func shouldUseReflection(options keyopts.GenOption) bool {
+	return options&keyopts.KeyOptUseReflectionType == keyopts.KeyOptUseReflectionType
+}
+
+func shouldPrefixPointer(options keyopts.GenOption) bool {
+	return options&keyopts.KeyOptIgnorePointer != keyopts.KeyOptIgnorePointer
+}
+
+func GetKey[T any](options keyopts.GenOption) types.BindKey {
+	if shouldUseReflection(options) {
+		return types.BindKey(TypeNameByReflect[T](shouldGenerify(options), shouldPrefixPointer(options)))
 	}
-	return types.BindKey(TypeName(options.GenerifyInterface, element))
+	return types.BindKey(TypeName[T](shouldGenerify(options), shouldPrefixPointer(options)))
+}
+
+func GetElemKey(element any, options keyopts.GenOption) types.BindKey {
+	if shouldUseReflection(options) {
+		return types.BindKey(TypeNameByReflect(shouldGenerify(options), shouldPrefixPointer(options), element))
+	}
+	return types.BindKey(TypeName(shouldGenerify(options), shouldPrefixPointer(options), element))
 }

--- a/remy/pkg/utils/type_key_test.go
+++ b/remy/pkg/utils/type_key_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"github.com/wrapped-owls/goremy-di/remy/pkg/keyopts"
 	"testing"
 
 	"github.com/wrapped-owls/goremy-di/remy/internal/types"
@@ -22,24 +23,24 @@ func TestGetKey__Generify(t *testing.T) {
 		}
 	)
 
-	options := types.ReflectionOptions{}
+	options := keyopts.KeyOptNone
 	if GetKey[super](options) == GetKey[sub](options) {
 		t.Error("type names was the same when should not generify")
 	}
 
-	options = types.ReflectionOptions{GenerifyInterface: true}
+	options = keyopts.KeyOptGenerifyInterface
 	if GetKey[super](options) != GetKey[sub](options) {
 		t.Error("generified type name should be the same")
 	}
 }
 
 func TestGetKey__SameStructWithDifferentPackage(t *testing.T) {
-	options := types.ReflectionOptions{UseReflectionType: true}
+	options := keyopts.KeyOptUseReflectionType
 	if GetKey[aTypes.Syringe](options) == GetKey[bTypes.Syringe](options) {
 		t.Error("type names was the same, when it should be different, because of different packages")
 	}
 
-	options = types.ReflectionOptions{UseReflectionType: true}
+	options = keyopts.KeyOptUseReflectionType
 	if GetElemKey(t, options) != GetKey[*testing.T](options) {
 		t.Error("element type should be the same from type and object")
 	}
@@ -58,8 +59,8 @@ func TestGetKey__Functions(t *testing.T) {
 		namedBoolCheckerCallback = func(languages ...string) bool
 	)
 
-	optionsCases := [...]types.ReflectionOptions{
-		{UseReflectionType: false}, {UseReflectionType: true},
+	optionsCases := [...]keyopts.GenOption{
+		keyopts.KeyOptNone, keyopts.KeyOptUseReflectionType,
 	}
 
 	for _, optCase := range optionsCases {

--- a/remy/test/fixtures/interfaces.go
+++ b/remy/test/fixtures/interfaces.go
@@ -1,0 +1,16 @@
+package fixtures
+
+type Language interface {
+	Name() string
+	Kind() string
+}
+
+type GoProgrammingLang struct{}
+
+func (g GoProgrammingLang) Name() string {
+	return "Go"
+}
+
+func (g GoProgrammingLang) Kind() string {
+	return "programming"
+}


### PR DESCRIPTION
- Add new option in `InstancePair` to bind interfaces
- Change the internal use of `ReflectionOptions` to use bitwise operators
    - In this way it'll be possible to add more internal options in the future
